### PR TITLE
docs(README): swap Clio CWS link forthcoming for branded URL (Closes #18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Seven-stage handler pipeline for consumer-facing AI product with independent sho
 
 Chrome extension for extracting full Gemini, Claude, and ChatGPT conversations to structured JSON with images. Strict-local processing, no telemetry. Designed around architectural-trust principles — capability declared in manifest, anything not declared is denied by the browser; the privacy claim doesn't depend on Clio's code *promising* not to call out, it depends on the browser *refusing* the call.
 
-**Available on Chrome Web Store** *(link forthcoming — pending publication)*
+**[Available on Chrome Web Store](https://thrivetech.ai/clio)**
 
 ---
 


### PR DESCRIPTION
## What

Replaces the placeholder

> **Available on Chrome Web Store** *(link forthcoming — pending publication)*

with

> **[Available on Chrome Web Store](https://thrivetech.ai/clio)**

## Why

Clio (`martymcenroe/Clio`) is now live on the Chrome Web Store. The branded short URL `https://thrivetech.ai/clio` redirects to the CWS listing via the new `clio/index.html` in `martymcenroe/thrivetech-ai` (PR #13 there). Verified live at HTTP 200 with the correct meta-refresh and canonical link.

The branded URL form was chosen over the raw CWS URL so the README has a single edit point if the extension ID ever changes, and so a `thrivetech.ai/<product>` convention can carry forward to future products.

Closes #18